### PR TITLE
Email indices from strings

### DIFF
--- a/src/email.adb
+++ b/src/email.adb
@@ -1,0 +1,57 @@
+with Ada.Containers.Formal_Vectors;
+
+package body Email with SPARK_Mode is
+
+   type Length_Type is range 0 .. 256;
+
+   type Email_Address_Buffer_Type is array (Length_Type range <>) of Character;
+
+   type Email_Address_Var_Type (Len : Length_Type := 20) is record
+      Ct : Email_Address_Buffer_Type (1 .. Len);
+   end record;
+
+   package Int_To_String is new
+     Ada.Containers.Formal_Vectors
+       (Index_Type => Valid_Email_Address_Type,
+        Element_Type => Email_Address_Var_Type);
+
+   Data : Int_To_String.Vector (1024);
+
+   --------------
+   -- Is_Valid --
+   --------------
+
+   function Is_Valid (X : Valid_Email_Address_Type) return Boolean is
+      (X <= Int_To_String.Last_Index (Data));
+
+   ----------------------
+   -- To_Email_Address --
+   ----------------------
+
+   procedure To_Email_Address (S : String;
+                               Email : out Email_Address_Type) is
+      use Ada.Containers;
+      Copy : constant String (1 .. S'Length) := S;
+   begin
+      -- ??? would like to guarantee unicity
+      if Int_To_String.Length (Data) < Max_Num_Emails then
+         Int_To_String.Append (Data, (Len => S'Length,
+                                      Ct => Email_Address_Buffer_Type (Copy)));
+         Email := Int_To_String.Last_Index (Data);
+      else
+         Email := No_Email;
+      end if;
+   end To_Email_Address;
+
+   ---------------
+   -- To_String --
+   ---------------
+
+   function To_String (E : Valid_Email_Address_Type) return String is
+      use Ada.Containers;
+   begin
+      pragma Assume (E <= Int_To_String.Last_Index (Data));
+      return String (Int_To_String.Element (Data, E).Ct);
+   end To_String;
+
+end Email;

--- a/src/email.adb
+++ b/src/email.adb
@@ -31,13 +31,19 @@ package body Email with SPARK_Mode is
    procedure To_Email_Address (S : String;
                                Email : out Email_Address_Type) is
       use Ada.Containers;
+      use Int_To_String;
       Copy : constant String (1 .. S'Length) := S;
    begin
-      -- ??? would like to guarantee unicity
-      if Int_To_String.Length (Data) < Max_Num_Emails then
-         Int_To_String.Append (Data, (Len => S'Length,
-                                      Ct => Email_Address_Buffer_Type (Copy)));
-         Email := Int_To_String.Last_Index (Data);
+      for Index in 1 .. Last_Index (Data) loop
+         if Element (Data, Index).Ct = Email_Address_Buffer_Type (Copy) then
+            Email := Index;
+            return;
+         end if;
+      end loop;
+      if Length (Data) < Max_Num_Emails then
+         Append (Data, (Len => S'Length,
+                        Ct => Email_Address_Buffer_Type (Copy)));
+         Email := Last_Index (Data);
       else
          Email := No_Email;
       end if;

--- a/src/email.adb
+++ b/src/email.adb
@@ -21,20 +21,28 @@ package body Email with SPARK_Mode is
    -- Is_Valid --
    --------------
 
-   function Is_Valid (X : Valid_Email_Address_Type) return Boolean is
-      (X <= Int_To_String.Last_Index (Data));
+   function Invariant return Boolean is
+     (for all I1 in 1 .. Int_To_String.Last_Index (Data) =>
+          (for all I2 in 1 .. Int_To_String.Last_Index (Data) =>
+             (if I1 /= I2 then
+                     Int_To_String.Element (Data, I1) /=
+                  Int_To_String.Element (Data, I2))));
 
    ----------------------
    -- To_Email_Address --
    ----------------------
 
    procedure To_Email_Address (S : String;
-                               Email : out Email_Address_Type) is
+                               Email : out Email_Address_Type)
+   is
       use Ada.Containers;
       use Int_To_String;
       Copy : constant String (1 .. S'Length) := S;
    begin
       for Index in 1 .. Last_Index (Data) loop
+         pragma Loop_Invariant
+           (for all K in 1 .. Index - 1 =>
+              Element (Data, K).Ct /= Email_Address_Buffer_Type (Copy));
          if Element (Data, Index).Ct = Email_Address_Buffer_Type (Copy) then
             Email := Index;
             return;
@@ -56,7 +64,9 @@ package body Email with SPARK_Mode is
    function To_String (E : Valid_Email_Address_Type) return String is
       use Ada.Containers;
    begin
-      pragma Assume (E <= Int_To_String.Last_Index (Data));
+      pragma Assume (E <= Int_To_String.Last_Index (Data),
+                     "only valid indices are created by this package " &
+                       "and the user doesn't play with the indices");
       return String (Int_To_String.Element (Data, E).Ct);
    end To_String;
 

--- a/src/email.ads
+++ b/src/email.ads
@@ -1,7 +1,24 @@
-package Email is
+package Email with SPARK_Mode is
 
-   type Email_Address_Type is new Integer; -- ???
+   --  emails are at most 256 characters long, see
+   --  https://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address
+
+   Max_Email_Length : constant := 256;
+   Max_Num_Emails : constant := 1024;
+
+   type Email_Address_Type is new Integer range 0 .. Max_Num_Emails;
+
+   subtype Valid_Email_Address_Type is Email_Address_Type
+   range 1 .. Email_Address_Type'Last;
 
    No_Email : constant Email_Address_Type := 0;
+
+   procedure To_Email_Address (S : String;
+                               Email : out Email_Address_Type)
+     with Pre => S'Length <= 256;
+      --  returns No_Email if email address integer could not be created
+
+   function To_String (E : Valid_Email_Address_Type) return String
+   with Post => To_String'Result'Length <= 256;
 
 end Email;

--- a/src/email.ads
+++ b/src/email.ads
@@ -13,12 +13,16 @@ package Email with SPARK_Mode is
 
    No_Email : constant Email_Address_Type := 0;
 
+   function Invariant return Boolean;
+
    procedure To_Email_Address (S : String;
                                Email : out Email_Address_Type)
-     with Pre => S'Length <= 256;
+     with Pre => S'Length <= 256 and then Invariant,
+          Post => Invariant;
       --  returns No_Email if email address integer could not be created
 
    function To_String (E : Valid_Email_Address_Type) return String
-   with Post => To_String'Result'Length <= 256;
+     with Pre => Invariant,
+          Post => To_String'Result'Length <= 256;
 
 end Email;


### PR DESCRIPTION
Email indices are now created from actual strings. Unicity of email indices is guaranteed using a (slow) search for an existing index before creating a new one.